### PR TITLE
Refactor : Interceptor Cached Token 사용으로 변경 (#7)

### DIFF
--- a/app/src/main/java/com/matzip/presentation/module/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/matzip/presentation/module/AuthenticationInterceptor.kt
@@ -13,7 +13,7 @@ class AuthenticationInterceptor@Inject constructor(
     private val matzipJwtRepository: MatzipJwtRepository
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): okhttp3.Response {
-        val accessToken = runBlocking { matzipJwtRepository.getAccessToken().first() }
+        val accessToken = matzipJwtRepository.getAccessToken()
 
         val request = chain.request().newBuilder()
             .addHeader("Authorization", "Bearer $accessToken").build()

--- a/app/src/main/java/com/matzip/presentation/module/RepositoryModule.kt
+++ b/app/src/main/java/com/matzip/presentation/module/RepositoryModule.kt
@@ -1,34 +1,11 @@
 package com.matzip.presentation.module
 
-import android.content.Context
-import com.matzip.data.repository.MatzipJwtRepositoryImpl
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import kotlinx.coroutines.runBlocking
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
     // TODO: 앞으로 사용될 Repository를 여기에 정의
-}
-
-@Module
-@InstallIn(SingletonComponent::class)
-object JwtModule {
-
-    @Provides
-    @Singleton
-    fun provideMatzipJwtRepository(
-        @ApplicationContext context: Context,
-    ): MatzipJwtRepositoryImpl {
-        val repository = MatzipJwtRepositoryImpl(context)
-        runBlocking {
-            repository.preloadTokens()
-        }
-        return repository
-    }
 }

--- a/app/src/main/java/com/matzip/presentation/module/RepositoryModule.kt
+++ b/app/src/main/java/com/matzip/presentation/module/RepositoryModule.kt
@@ -1,11 +1,34 @@
 package com.matzip.presentation.module
 
+import android.content.Context
+import com.matzip.data.repository.MatzipJwtRepositoryImpl
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.runBlocking
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
     // TODO: 앞으로 사용될 Repository를 여기에 정의
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object JwtModule {
+
+    @Provides
+    @Singleton
+    fun provideMatzipJwtRepository(
+        @ApplicationContext context: Context,
+    ): MatzipJwtRepositoryImpl {
+        val repository = MatzipJwtRepositoryImpl(context)
+        runBlocking {
+            repository.preloadTokens()
+        }
+        return repository
+    }
 }

--- a/app/src/main/java/com/matzip/presentation/module/TokenAuthenticator.kt
+++ b/app/src/main/java/com/matzip/presentation/module/TokenAuthenticator.kt
@@ -23,8 +23,8 @@ class TokenAuthenticator @Inject constructor(
     private val mutex = Mutex()
 
     override fun authenticate(route: Route?, response: okhttp3.Response): Request? = runBlocking {
-        val accessToken = matzipJwtRepository.getCachedAccessToken() ?: matzipJwtRepository.getAccessToken().first()
-        val refreshToken = matzipJwtRepository.getCachedRefreshToken() ?: matzipJwtRepository.getRefreshToken().first()
+        val accessToken = matzipJwtRepository.getAccessToken()
+        val refreshToken = matzipJwtRepository.getRefreshToken()
 
         // 동기화된 블록을 사용하여 토큰 갱신 작업을 안전하게 수행
         mutex.withLock {
@@ -35,7 +35,7 @@ class TokenAuthenticator @Inject constructor(
                     .removeHeader("Authorization")
                     .header(
                         "Authorization",
-                        "Bearer ${matzipJwtRepository.getCachedAccessToken() ?: matzipJwtRepository.getAccessToken().first()}"
+                        "Bearer ${matzipJwtRepository.getAccessToken()}"
                     )
                     .build()
             } else null
@@ -47,7 +47,7 @@ class TokenAuthenticator @Inject constructor(
         access: String,
         refresh: String
     ): Boolean {
-        val newAccess = matzipJwtRepository.getAccessToken().first()
+        val newAccess = matzipJwtRepository.getAccessToken()
         // 토큰 재발급
         return if (access != newAccess) true else {
             Log.d("RETROFIT","TokenAuthenticator - authenticate() called / 토큰 만료. 토큰 Refresh 요청: $refresh")

--- a/app/src/main/java/com/matzip/presentation/module/TokenAuthenticator.kt
+++ b/app/src/main/java/com/matzip/presentation/module/TokenAuthenticator.kt
@@ -35,7 +35,7 @@ class TokenAuthenticator @Inject constructor(
                     .removeHeader("Authorization")
                     .header(
                         "Authorization",
-                        "Bearer $accessToken"
+                        "Bearer ${matzipJwtRepository.getCachedAccessToken() ?: matzipJwtRepository.getAccessToken().first()}"
                     )
                     .build()
             } else null

--- a/app/src/main/java/com/matzip/presentation/module/TokenAuthenticator.kt
+++ b/app/src/main/java/com/matzip/presentation/module/TokenAuthenticator.kt
@@ -23,10 +23,8 @@ class TokenAuthenticator @Inject constructor(
     private val mutex = Mutex()
 
     override fun authenticate(route: Route?, response: okhttp3.Response): Request? = runBlocking {
-        val access = async { matzipJwtRepository.getAccessToken().first() }
-        val refresh = async { matzipJwtRepository.getRefreshToken().first() }
-        val accessToken = access.await()
-        val refreshToken = refresh.await()
+        val accessToken = matzipJwtRepository.getCachedAccessToken() ?: matzipJwtRepository.getAccessToken().first()
+        val refreshToken = matzipJwtRepository.getCachedRefreshToken() ?: matzipJwtRepository.getRefreshToken().first()
 
         // 동기화된 블록을 사용하여 토큰 갱신 작업을 안전하게 수행
         mutex.withLock {
@@ -37,7 +35,7 @@ class TokenAuthenticator @Inject constructor(
                     .removeHeader("Authorization")
                     .header(
                         "Authorization",
-                        "Bearer " + matzipJwtRepository.getAccessToken().first()
+                        "Bearer $accessToken"
                     )
                     .build()
             } else null

--- a/data/src/main/java/com/matzip/data/repository/MatzipJwtRepositoryImpl.kt
+++ b/data/src/main/java/com/matzip/data/repository/MatzipJwtRepositoryImpl.kt
@@ -25,12 +25,18 @@ class MatzipJwtRepositoryImpl @Inject constructor(
         // cachedRefreshToken = request.refreshToken
     }
 
-    override fun getAccessToken(): Flow<String> {
-        TODO("Not yet implemented")
+    override fun getAccessToken(): String {
+        if(cachedAccessToken.isNullOrEmpty()) {
+            // TODO DataStore에서 토큰을 가져와 캐시 하는 로직
+        }
+        return cachedAccessToken!!
     }
 
-    override fun getRefreshToken(): Flow<String> {
-        TODO("Not yet implemented")
+    override fun getRefreshToken(): String {
+        if(cachedAccessToken.isNullOrEmpty()) {
+            // TODO DataStore에서 토큰을 가져와 캐시 하는 로직
+        }
+        return cachedRefreshToken!!
     }
 
     override suspend fun reIssueToken(request: String): Flow<ApiState<MatzipJwtResponseVo>> {
@@ -44,7 +50,4 @@ class MatzipJwtRepositoryImpl @Inject constructor(
 //        cachedRefreshToken = prefs[REFRESH_TOKEN_KEY]
 
     }
-
-    override suspend fun getCachedAccessToken(): String? = cachedAccessToken
-    override suspend fun getCachedRefreshToken(): String? = cachedRefreshToken
 }

--- a/data/src/main/java/com/matzip/data/repository/MatzipJwtRepositoryImpl.kt
+++ b/data/src/main/java/com/matzip/data/repository/MatzipJwtRepositoryImpl.kt
@@ -13,11 +13,16 @@ import javax.inject.Inject
 class MatzipJwtRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : MatzipJwtRepository {
+    @Volatile
     private var cachedAccessToken: String? = null
+    @Volatile
     private var cachedRefreshToken: String? = null
 
     override suspend fun saveAccessTokenAndRefreshToken(request: SaveMatzipJwtRequestVo): Flow<Boolean> {
         TODO("Not yet implemented")
+        // TODO DataStore를 사용하여 토큰을 저장하는 로직
+        // cachedAccessToken = request.accessToken
+        // cachedRefreshToken = request.refreshToken
     }
 
     override fun getAccessToken(): Flow<String> {

--- a/data/src/main/java/com/matzip/data/repository/MatzipJwtRepositoryImpl.kt
+++ b/data/src/main/java/com/matzip/data/repository/MatzipJwtRepositoryImpl.kt
@@ -13,6 +13,9 @@ import javax.inject.Inject
 class MatzipJwtRepositoryImpl @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : MatzipJwtRepository {
+    private var cachedAccessToken: String? = null
+    private var cachedRefreshToken: String? = null
+
     override suspend fun saveAccessTokenAndRefreshToken(request: SaveMatzipJwtRequestVo): Flow<Boolean> {
         TODO("Not yet implemented")
     }
@@ -29,11 +32,14 @@ class MatzipJwtRepositoryImpl @Inject constructor(
         TODO("Not yet implemented")
     }
 
-    suspend fun preloadTokens() {
+    override suspend fun preloadTokens() {
         // TODO DataStore를 사용하여 토큰을 미리 캐시하는 로직
 //        val prefs = context.dataStore.data.first()
 //        cachedAccessToken = prefs[ACCESS_TOKEN_KEY]
 //        cachedRefreshToken = prefs[REFRESH_TOKEN_KEY]
 
     }
+
+    override suspend fun getCachedAccessToken(): String? = cachedAccessToken
+    override suspend fun getCachedRefreshToken(): String? = cachedRefreshToken
 }

--- a/data/src/main/java/com/matzip/data/repository/MatzipJwtRepositoryImpl.kt
+++ b/data/src/main/java/com/matzip/data/repository/MatzipJwtRepositoryImpl.kt
@@ -28,4 +28,12 @@ class MatzipJwtRepositoryImpl @Inject constructor(
     override suspend fun reIssueToken(request: String): Flow<ApiState<MatzipJwtResponseVo>> {
         TODO("Not yet implemented")
     }
+
+    suspend fun preloadTokens() {
+        // TODO DataStore를 사용하여 토큰을 미리 캐시하는 로직
+//        val prefs = context.dataStore.data.first()
+//        cachedAccessToken = prefs[ACCESS_TOKEN_KEY]
+//        cachedRefreshToken = prefs[REFRESH_TOKEN_KEY]
+
+    }
 }

--- a/domain/src/main/java/com/matzip/domain/repository/MatzipJwtRepository.kt
+++ b/domain/src/main/java/com/matzip/domain/repository/MatzipJwtRepository.kt
@@ -11,4 +11,8 @@ interface MatzipJwtRepository {
     fun getAccessToken(): Flow<String>
     fun getRefreshToken(): Flow<String>
     suspend fun reIssueToken(request : String): Flow<ApiState<MatzipJwtResponseVo>>
+    suspend fun preloadTokens() // 미리 토큰을 로드하는 함수
+    suspend fun getCachedAccessToken(): String?
+    suspend fun getCachedRefreshToken(): String?
+
 }

--- a/domain/src/main/java/com/matzip/domain/repository/MatzipJwtRepository.kt
+++ b/domain/src/main/java/com/matzip/domain/repository/MatzipJwtRepository.kt
@@ -8,11 +8,9 @@ import kotlinx.coroutines.flow.Flow
 interface MatzipJwtRepository {
 
     suspend fun saveAccessTokenAndRefreshToken(request: SaveMatzipJwtRequestVo): Flow<Boolean>
-    fun getAccessToken(): Flow<String>
-    fun getRefreshToken(): Flow<String>
+    fun getAccessToken(): String
+    fun getRefreshToken(): String
     suspend fun reIssueToken(request : String): Flow<ApiState<MatzipJwtResponseVo>>
     suspend fun preloadTokens() // 미리 토큰을 로드하는 함수
-    suspend fun getCachedAccessToken(): String?
-    suspend fun getCachedRefreshToken(): String?
 
 }


### PR DESCRIPTION
## 🔎 작업 내용

기존에는 runBlocking 함수를 사용하여 비동기 코루틴을 강제로 동기로 작업하게끔 만들었으나 이는 문제가 있다고 판단하여 DI단계에서 미리 토큰을 가져와 이를 캐시하는 방법을 채택하였습니다.
따라서 Interceptor에서 이제 accessToken은 캐시된 토큰을 사용하고, 그와 더불어 TokenAuthenticator class에서도 이미 캐시된 accessToken, refreshToken이 존재하여 지속적으로 dataStore에 접근하는 비용을 줄였습니다.

<br/>

## 🔧 앞으로의 과제

Domain모듈 작업이 생각보다 아예 없을 것 같습니다. 이 다음으로 feature의 베이스 작업을 바로 진행하도록 하겠습니다
주요 작업 목록은 디자인 시스템, BaseViewModel 등 큰 틀을 잡는 작업을 진행할 예정이고 그 작업이 완료된 이후에 준희님 파트 작업 시작하시면 될 것 같습니다.

  <br/>

## ➕ 이슈 링크

- [ #7 ]

<br/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 토큰 관리 방식이 비동기(Flow)에서 동기(String 반환)로 변경되어 토큰 접근이 간소화되었습니다.
  * 토큰을 메모리에 캐싱하여 성능이 개선될 수 있도록 구조가 변경되었습니다.
  * 토큰 사전 로딩(preload) 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->